### PR TITLE
audit report comparing CWRC and Swift contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,34 @@ time to run it. All debug messages redirected to STDOUT. If you want it to appea
 cwrc_preserver.rb -r
 ```
 
-### Reporting
+### Reporting / auditing 
 
 ```shell
 Usage: cwrc_audit_report [options]
     -s, --summary                    Summary output where status is not 'ok'
     -h, --help                       Displays help
 ```
-Builds a CSV formatted audit report comparing the CWRC content to UAL Swift content.
-    
-The report lists the CWRC object PIDs and modification date/times and links to the associated Swift object displaying the Swift ID, modification time, and size along with a column indicating the preservation status (i.e., indicating if modification time comparison between Swift and CWRC indicate a need for preservation, or if the size of the Swift object is zero, etc)
+
+Builds a CSV formatted audit report comparing content within the CWRC repository relative to UAL's OpenStack Swift preserved content.
+
+The report pulls input from two disparate sources: CWRC repository and UAL OpenStack Swift preservation service. The report links the content based on object id and outputs the linked information in csv rows that included the fields: the CWRC object PIDs and modification date/times, UAL Swift ID, modification time, and size along with a column indicating the preservation status (i.e., indicating if modification time comparison between Swift and CWRC indicates a need for preservation, or if the size of the Swift object is zero, etc)    
+
+The output format is CSV with the following header columns:
+```
+     CWRC PID,
+     CWRC modification,
+     Swift ID,
+     Swift modification time,
+     Swift size,
+     Status
+
+     where:
+       status =
+          if 'x' then needs preservation
+           else if 'd' then not present within CWRC
+           else if 'x' then Swift object is of zero size
+           else '' then ok
+```
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,18 @@ time to run it. All debug messages redirected to STDOUT. If you want it to appea
 cwrc_preserver.rb -r
 ```
 
-- Troubleshooting
+### Reporting
+
+```shell
+Usage: cwrc_audit_report [options]
+    -s, --summary                    Summary output where status is not 'ok'
+    -h, --help                       Displays help
+```
+Builds a CSV formatted audit report comparing the CWRC content to UAL Swift content.
+    
+The report lists the CWRC object PIDs and modification date/times and links to the associated Swift object displaying the Swift ID, modification time, and size along with a column indicating the preservation status (i.e., indicating if modification time comparison between Swift and CWRC indicate a need for preservation, or if the size of the Swift object is zero, etc)
+
+### Troubleshooting
 
 We have implemented reuse of cookies using connection_cookie.txt file. If CWRC server is reset and will not recognize
 previously issued cookie (even though it did not expire), simply delete connection_cookie.txt

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -105,7 +105,7 @@ module CWRCPerserver
     cwrc_pid = cwrc_obj['pid']
     cwrc_mtime = cwrc_obj['timestamp']
     # account for the CWRC PID ':' replaced with "_" in the Swift ID
-    swift_id = cwrc_pid.sub! ':', '_'
+    swift_id = cwrc_pid.sub ':', '_'
 
     if swift_objs.key?(swift_id)
       swift_timestamp = swift_objs[swift_id][:last_modified]

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -1,35 +1,36 @@
 #!/usr/bin/env ruby
 
-# Builds a CSV formatted audit report comparing the CWRC content to UAL Swift 
+# Builds a CSV formatted audit report comparing the CWRC content to UAL Swift
 # content.
 #
-# The report lists the CWRC object PIDs and modification date/times 
-# and links to the associated Swift object displaying the Swift ID, 
-# modification time, and size along with a column indicating 
-# the preservation status (e.g., indicating if modification times match for 
-# each object, the size of the Swift object is zero, etc)
+# The report lists the CWRC object PIDs and modification date/times
+# and links to the associated Swift object displaying the Swift ID,
+# modification time, and size along with a column indicating
+# the preservation status (i.e., indicating if modification time
+# comparison between Swift and CWRC indicate a need for preservation,
+# or if the size of the Swift object is zero, etc
 #
-# The output format is CSV with the following header columes: 
+# The output format is CSV with the following header columes:
 #     CWRC PID,
 #     CWRC modification,
 #     Swift ID,
 #     Swift modification time,
 #     Swift size,
 #     Status
-# 
+#
 #     where:
-#       status: 
+#       status:
 #          if 'x' then needs preservation
 #           else if 'd' then not present within cwrc
-#           else if 'x' then Swift object is of zero size 
-#           else '' then ok 
+#           else if 'x' then Swift object is of zero size
+#           else '' then ok
 #
 # Usage: <progname> [options]...
 #   options
-#     -h --help 
+#     -h --help
 #     -s --summary summary output where status in not 'ok'
 #
-# The following is a kludgy, quick and dirty report written by a 
+# The following is a kludgy, quick and dirty report written by a
 # non-Ruby programmer - 2018-05-03
 
 require 'logger'
@@ -39,21 +40,20 @@ require 'swift_ingest'
 
 require_relative 'cwrc_common'
 
-
-module CWRCPerserver 
+module CWRCPerserver
 
   # status IDs
   STATUS_OK = ''
-  STATUS_E_SIZE = 's' # error: size zero to too small
+  STATUS_E_SIZE = 's' # error: size zero or too small
   STATUS_I_FLAG = 'x' # flagged for preservation
-  STATUS_I_DEL = 'd' # missing from the CWRC side while Swift contains a copy 
+  STATUS_I_DEL = 'd' # missing from the CWRC side while Swift contains a copy
 
   opt_summary_output = false
   ARGV.options do |opts|
     opts.on('-s', '--summary', "Summary output where status is not 'ok'") do
       opt_summary_output = true
-    end 
-    opts.on_tail('-h', '--help', "Displays help") do 
+    end
+    opts.on_tail('-h', '--help', 'Displays help') do
       puts opts
       exit
     end
@@ -68,18 +68,21 @@ module CWRCPerserver
 
   # query the CWRC repository
   # {"pid"=>"cwrc:c1583789-0dad-41d3-8a42-94d7a8e6d451", "timestamp"=>"2018-05-02T17:07:29.028Z"}
-  # cwrc_objs = {} 
+  # cwrc_objs = {}
   cwrc_objs = get_cwrc_objs(cookie, '')
 
   # connect to swift storage
   swift_con = connect_to_swift
   raise CWRCArchivingError if swift_con.nil?
 
-  #query Swift storage for a list of objects
+  # query Swift storage for a list of objects
   # https://github.com/ruby-openstack/ruby-openstack/wiki/Object-Storage
   # https://github.com/ruby-openstack/ruby-openstack/wiki/Object-Storage
   # "cwrc_0c168793-b1ff-453f-a1f6-e1d75f7350be"=>{
-  #    :bytes=>"5939", :content_type=>"application/x-tar", :last_modified=>"2018-02-05T06:45:23.422720", :hash=>"dd2b11f239f7f25fb504519b612cf896"
+  #    :bytes=>"5939",
+  #    :content_type=>"application/x-tar",
+  #    :last_modified=>"2018-02-05T06:45:23.422720",
+  #    :hash=>"dd2b11f239f7f25fb504519b612cf896"
   #  },
   swift_container = swift_con.swift_connection.container(swift_con.project)
 
@@ -89,52 +92,54 @@ module CWRCPerserver
   # https://github.com/ruby-openstack/ruby-openstack/issues/37
   # https://github.com/ruby-openstack/ruby-openstack/blob/master/lib/openstack/swift/container.rb#L100
 
-  swift_objs_limit = 10000
-  swift_objs = swift_container.objects_detail(:limit => swift_objs_limit)
-  while swift_objs.count < swift_container.container_metadata[:count].to_i do
-    last_key = swift_objs.keys.last
-    tmp = swift_container.objects_detail(:limit => swift_objs_limit, :marker => last_key)
-    swift_objs = swift_objs.merge(tmp)
+  swift_objs = swift_container.objects_detail()
+  while swift_objs.count < swift_container.container_metadata[:count].to_i 
+    swift_objs = swift_objs.merge(
+                   swift_container.objects_detail(marker: swift_objs.keys.last)
+                   )
   end
 
-  # ToDo: use CSV gem
+  # TODO: use CSV gem
   # CSV header
-  puts "cwrc_pid (#{cwrc_objs.count}),cwrc_mtime (#{DateTime.now}),swift_id (#{swift_container.container_metadata[:count]}),swift_timestamp,swift_bytes,status"
+  puts "cwrc_pid (#{cwrc_objs.count}),"\
+    "cwrc_mtime (#{DateTime.now}),"\
+    "swift_id (#{swift_container.container_metadata[:count]}),"\
+    "swift_timestamp,swift_bytes,status"
 
-  # ToDo: find a better way to merge CWRC and Swift hashes into an output format
+  # TODO: find a better way to merge CWRC and Swift hashes into an output format
   # for each cwrc object
-  #p "Connections between Swift and CWRC" 
+  # p "Connections between Swift and CWRC"
   cwrc_objs&.each do |cwrc_obj|
     cwrc_pid = cwrc_obj['pid'].to_s
     cwrc_mtime = cwrc_obj['timestamp'].to_s
     swift_id = cwrc_pid.dup
     # account for the CWRC PID ':' replaced with "_" in the Swift ID
-    swift_id.sub! ":", "_"
+    swift_id.sub! ':', '_'
 
-    if swift_objs.has_key?(swift_id)
-      swift_id = swift_id 
+    if swift_objs.key?(swift_id)
+      swift_id = swift_id
       swift_timestamp = swift_objs[swift_id][:last_modified].dup
       swift_bytes = swift_objs[swift_id][:bytes].dup
       # note: CWRC uses zulo while Swift is local timezone (assumption)
       # is timestamps don't match report if Swift behind CWRC
-      if DateTime.parse(cwrc_mtime) > DateTime.parse(swift_timestamp)
-        status = STATUS_I_FLAG 
-      elsif swift_bytes.to_i < 20
-        status = STATUS_E_SIZE 
-      else
-        status = STATUS_OK 
-      end
+      status = if Time.parse(cwrc_mtime) > Time.parse(swift_timestamp)
+                 STATUS_I_FLAG
+               elsif swift_bytes.to_i < 20
+                 STATUS_E_SIZE
+               else
+                 STATUS_OK
+               end
       swift_objs.delete(swift_id)
     else
       # Swift missing the CWRC object, status and empty Swift columes reported
-      swift_id = '' 
+      swift_id = ''
       swift_timestamp = ''
       swift_bytes = ''
       status = STATUS_I_FLAG
     end
-   
-    #CSV content 
-    if !opt_summary_output or (opt_summary_output and status != STATUS_OK) 
+
+    # CSV content
+    if !opt_summary_output || (opt_summary_output && status != STATUS_OK)
       puts "#{cwrc_pid},#{cwrc_mtime},#{swift_id},#{swift_timestamp},#{swift_bytes},#{status}"
     end
 
@@ -143,7 +148,7 @@ module CWRCPerserver
   # find the remaining Swift objects that don't have corresponding items in CWRC
   # p "Remaining Swift objects; objects not found in CWRC (likely deleted by CWRC)"
   swift_objs&.each do |key, swift_obj|
-    #CSV content
+    # CSV content
     puts ",,#{key},#{swift_obj[:last_modified]},#{swift_obj[:bytes]},d"
   end
 

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+
+# Builds a CSV formatted audit report comparing the CWRC content to UAL Swift 
+# content.
+#
+# The report lists the CWRC object PIDs and modification date/times 
+# and links to the associated Swift object displaying the Swift ID, 
+# modification time, and size along with a column indicating 
+# the preservation status (e.g., indicating if modification times match for 
+# each object, the size of the Swift object is zero, etc)
+#
+# The output format is CSV with the following header columes: 
+#     CWRC PID,
+#     CWRC modification,
+#     Swift ID,
+#     Swift modification time,
+#     Swift size,
+#     Status
+# 
+#     where:
+#       status: 
+#          if 'x' then needs preservation
+#           else if 'd' then not present within cwrc
+#           else if 'x' then Swift object is of zero size 
+#           else '' then ok 
+#
+# Usage: <progname> [options]...
+#   options
+#     -h --help 
+#     -s --summary summary output where status in not 'ok'
+#
+# The following is a kludgy, quick and dirty report written by a 
+# non-Ruby programmer - 2018-05-03
+
+require 'logger'
+require 'optparse'
+require 'time'
+require 'swift_ingest'
+
+require_relative 'cwrc_common'
+
+
+module CWRCPerserver 
+
+  # status IDs
+  STATUS_OK = ''
+  STATUS_E_SIZE = 's' # error: size zero to too small
+  STATUS_I_FLAG = 'x' # flagged for preservation
+  STATUS_I_DEL = 'd' # missing from the CWRC side while Swift contains a copy 
+
+  opt_summary_output = false
+  ARGV.options do |opts|
+    opts.on('-s', '--summary', "Summary output where status is not 'ok'") do
+      opt_summary_output = true
+    end 
+    opts.on_tail('-h', '--help', "Displays help") do 
+      puts opts
+      exit
+    end
+    opts.parse!
+  end
+
+  # initialize environment
+  set_env
+
+  # authenicate to CWRC repository
+  cookie = retrieve_cookie
+
+  # query the CWRC repository
+  # {"pid"=>"cwrc:c1583789-0dad-41d3-8a42-94d7a8e6d451", "timestamp"=>"2018-05-02T17:07:29.028Z"}
+  # cwrc_objs = {} 
+  cwrc_objs = get_cwrc_objs(cookie, '')
+
+  # connect to swift storage
+  swift_con = connect_to_swift
+  raise CWRCArchivingError if swift_con.nil?
+
+  #query Swift storage for a list of objects
+  # https://github.com/ruby-openstack/ruby-openstack/wiki/Object-Storage
+  # https://github.com/ruby-openstack/ruby-openstack/wiki/Object-Storage
+  # "cwrc_0c168793-b1ff-453f-a1f6-e1d75f7350be"=>{
+  #    :bytes=>"5939", :content_type=>"application/x-tar", :last_modified=>"2018-02-05T06:45:23.422720", :hash=>"dd2b11f239f7f25fb504519b612cf896"
+  #  },
+  swift_container = swift_con.swift_connection.container(swift_con.project)
+
+
+  # ugly kludge for bug in ruby-openstack - no iterator or pagination
+  # unable pagination using markers - assume order stays the same
+  # https://github.com/ruby-openstack/ruby-openstack/issues/37
+  # https://github.com/ruby-openstack/ruby-openstack/blob/master/lib/openstack/swift/container.rb#L100
+
+  swift_objs_limit = 10000
+  swift_objs = swift_container.objects_detail(:limit => swift_objs_limit)
+  while swift_objs.count < swift_container.container_metadata[:count].to_i do
+    last_key = swift_objs.keys.last
+    tmp = swift_container.objects_detail(:limit => swift_objs_limit, :marker => last_key)
+    swift_objs = swift_objs.merge(tmp)
+  end
+
+  # ToDo: use CSV gem
+  # CSV header
+  puts "cwrc_pid (#{cwrc_objs.count}),cwrc_mtime (#{DateTime.now}),swift_id (#{swift_container.container_metadata[:count]}),swift_timestamp,swift_bytes,status"
+
+  # ToDo: find a better way to merge CWRC and Swift hashes into an output format
+  # for each cwrc object
+  #p "Connections between Swift and CWRC" 
+  cwrc_objs&.each do |cwrc_obj|
+    cwrc_pid = cwrc_obj['pid'].to_s
+    cwrc_mtime = cwrc_obj['timestamp'].to_s
+    swift_id = cwrc_pid.dup
+    # account for the CWRC PID ':' replaced with "_" in the Swift ID
+    swift_id.sub! ":", "_"
+
+    if swift_objs.has_key?(swift_id)
+      swift_id = swift_id 
+      swift_timestamp = swift_objs[swift_id][:last_modified].dup
+      swift_bytes = swift_objs[swift_id][:bytes].dup
+      # note: CWRC uses zulo while Swift is local timezone (assumption)
+      # is timestamps don't match report if Swift behind CWRC
+      if DateTime.parse(cwrc_mtime) > DateTime.parse(swift_timestamp)
+        status = STATUS_I_FLAG 
+      elsif swift_bytes.to_i < 20
+        status = STATUS_E_SIZE 
+      else
+        status = STATUS_OK 
+      end
+      swift_objs.delete(swift_id)
+    else
+      # Swift missing the CWRC object, status and empty Swift columes reported
+      swift_id = '' 
+      swift_timestamp = ''
+      swift_bytes = ''
+      status = STATUS_I_FLAG
+    end
+   
+    #CSV content 
+    if !opt_summary_output or (opt_summary_output and status != STATUS_OK) 
+      puts "#{cwrc_pid},#{cwrc_mtime},#{swift_id},#{swift_timestamp},#{swift_bytes},#{status}"
+    end
+
+  end
+
+  # find the remaining Swift objects that don't have corresponding items in CWRC
+  # p "Remaining Swift objects; objects not found in CWRC (likely deleted by CWRC)"
+  swift_objs&.each do |key, swift_obj|
+    #CSV content
+    puts ",,#{key},#{swift_obj[:last_modified]},#{swift_obj[:bytes]},d"
+  end
+
+end

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -85,7 +85,6 @@ module CWRCPerserver
   #  },
   swift_container = swift_con.swift_connection.container(swift_con.project)
 
-
   # ugly kludge for bug in ruby-openstack - no iterator or pagination
   # unable pagination using markers - assume order stays the same
   # https://github.com/ruby-openstack/ruby-openstack/issues/37

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -95,23 +95,21 @@ module CWRCPerserver
   # TODO: use CSV gem
   # CSV header
   puts "cwrc_pid (#{cwrc_objs.count}),"\
-    "cwrc_mtime (#{Time.now}),"\
+    "cwrc_mtime (#{Time.now.iso8601}),"\
     "swift_id (#{swift_container.container_metadata[:count]}),"\
     'swift_timestamp,swift_bytes,status'
 
   # TODO: find a better way to merge CWRC and Swift hashes into an output format
   # for each cwrc object
   cwrc_objs&.each do |cwrc_obj|
-    cwrc_pid = cwrc_obj['pid'].to_s
-    cwrc_mtime = cwrc_obj['timestamp'].to_s
-    swift_id = cwrc_pid.dup
+    cwrc_pid = cwrc_obj['pid']
+    cwrc_mtime = cwrc_obj['timestamp']
     # account for the CWRC PID ':' replaced with "_" in the Swift ID
-    swift_id.sub! ':', '_'
+    swift_id = cwrc_pid.sub! ':', '_'
 
     if swift_objs.key?(swift_id)
-      swift_id = swift_id
-      swift_timestamp = swift_objs[swift_id][:last_modified].dup
-      swift_bytes = swift_objs[swift_id][:bytes].dup
+      swift_timestamp = swift_objs[swift_id][:last_modified]
+      swift_bytes = swift_objs[swift_id][:bytes]
       # note: CWRC uses zulu while Swift is local timezone (assumption)
       # If timestamps don't match then report Swift object older than CWRC
       status = if Time.parse(cwrc_mtime) > Time.parse(swift_timestamp)
@@ -139,6 +137,6 @@ module CWRCPerserver
   # find the remaining Swift objects that don't have corresponding items in CWRC
   swift_objs&.each do |key, swift_obj|
     # CSV content
-    puts ",,#{key},#{swift_obj[:last_modified]},#{swift_obj[:bytes]},d"
+    puts ",,#{key},#{swift_obj[:last_modified]},#{swift_obj[:bytes]},#{STATUS_I_DEL}"
   end
 end

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -1,16 +1,19 @@
 #!/usr/bin/env ruby
 
-# Builds a CSV formatted audit report comparing the CWRC content to UAL Swift
-# content.
+# Builds a CSV formatted audit report comparing content within the
+# CWRC repository relative to UAL's OpenStack Swift preserved content.
 #
-# The report lists the CWRC object PIDs and modification date/times
-# and links to the associated Swift object displaying the Swift ID,
-# modification time, and size along with a column indicating
-# the preservation status (i.e., indicating if modification time
-# comparison between Swift and CWRC indicate a need for preservation,
-# or if the size of the Swift object is zero, etc
+# The report pulls input from two disparate sources: CWRC repository and
+# UAL OpenStack Swift preservation service. The report links the content based
+# on object id and outputs the linked information in csv rows that included the
+# fields: the CWRC object PIDs and modification date/times, UAL Swift ID,
+# modification time, and size along with a column indicating the preservation
+# status (i.e., indicating if modification time comparison between Swift and
+# CWRC indicates a need for preservation, or if the size of the Swift object
+# is zero, etc)
+
 #
-# The output format is CSV with the following header columes:
+# The output format is CSV with the following header columns:
 #     CWRC PID,
 #     CWRC modification,
 #     Swift ID,
@@ -19,9 +22,9 @@
 #     Status
 #
 #     where:
-#       status:
+#       status =
 #          if 'x' then needs preservation
-#           else if 'd' then not present within cwrc
+#           else if 'd' then not present within CWRC
 #           else if 'x' then Swift object is of zero size
 #           else '' then ok
 #
@@ -30,8 +33,6 @@
 #     -h --help
 #     -s --summary summary output where status in not 'ok'
 #
-# The following is a kludgy, quick and dirty report written by a
-# non-Ruby programmer - 2018-05-03
 
 require 'logger'
 require 'optparse'
@@ -62,12 +63,11 @@ module CWRCPerserver
   # initialize environment
   set_env
 
-  # authenicate to CWRC repository
+  # authenticate to CWRC repository
   cookie = retrieve_cookie
 
   # query the CWRC repository
-  # {"pid"=>"cwrc:c1583789-0dad-41d3-8a42-94d7a8e6d451", "timestamp"=>"2018-05-02T17:07:29.028Z"}
-  # cwrc_objs = {}
+  # response: {"pid"=>"cwrc:c1583789-0dad-41d3-8a42-94d7a8e6d451", "timestamp"=>"2018-05-02T17:07:29.028Z"}
   cwrc_objs = get_cwrc_objs(cookie, '')
 
   # connect to swift storage
@@ -77,7 +77,7 @@ module CWRCPerserver
   # query Swift storage for a list of objects
   # https://github.com/ruby-openstack/ruby-openstack/wiki/Object-Storage
   # https://github.com/ruby-openstack/ruby-openstack/wiki/Object-Storage
-  # "cwrc_0c168793-b1ff-453f-a1f6-e1d75f7350be"=>{
+  # response: "cwrc_0c168793-b1ff-453f-a1f6-e1d75f7350be"=>{
   #    :bytes=>"5939",
   #    :content_type=>"application/x-tar",
   #    :last_modified=>"2018-02-05T06:45:23.422720",
@@ -85,11 +85,8 @@ module CWRCPerserver
   #  },
   swift_container = swift_con.swift_connection.container(swift_con.project)
 
-  # ugly kludge for bug in ruby-openstack - no iterator or pagination
-  # unable pagination using markers - assume order stays the same
-  # https://github.com/ruby-openstack/ruby-openstack/issues/37
-  # https://github.com/ruby-openstack/ruby-openstack/blob/master/lib/openstack/swift/container.rb#L100
-
+  # Iterate via markers
+  # https://github.com/ruby-openstack/ruby-openstack/blob/d9c8aa19488062e483771a9168d24f2626fe688b/lib/openstack/swift/container.rb#L100
   swift_objs = swift_container.objects_detail
   while swift_objs.count < swift_container.container_metadata[:count].to_i
     swift_objs = swift_objs.merge(swift_container.objects_detail(marker: swift_objs.keys.last))
@@ -104,7 +101,6 @@ module CWRCPerserver
 
   # TODO: find a better way to merge CWRC and Swift hashes into an output format
   # for each cwrc object
-  # p "Connections between Swift and CWRC"
   cwrc_objs&.each do |cwrc_obj|
     cwrc_pid = cwrc_obj['pid'].to_s
     cwrc_mtime = cwrc_obj['timestamp'].to_s
@@ -116,18 +112,18 @@ module CWRCPerserver
       swift_id = swift_id
       swift_timestamp = swift_objs[swift_id][:last_modified].dup
       swift_bytes = swift_objs[swift_id][:bytes].dup
-      # note: CWRC uses zulo while Swift is local timezone (assumption)
-      # is timestamps don't match report if Swift behind CWRC
+      # note: CWRC uses zulu while Swift is local timezone (assumption)
+      # If timestamps don't match then report Swift object older than CWRC
       status = if Time.parse(cwrc_mtime) > Time.parse(swift_timestamp)
                  STATUS_I_FLAG
-               elsif swift_bytes.to_i < 20
+               elsif swift_bytes.to_i < 20 # object too small
                  STATUS_E_SIZE
                else
                  STATUS_OK
                end
       swift_objs.delete(swift_id)
     else
-      # Swift missing the CWRC object, status and empty Swift columes reported
+      # Swift missing the CWRC object, status and empty Swift columns reported
       swift_id = ''
       swift_timestamp = ''
       swift_bytes = ''
@@ -141,7 +137,6 @@ module CWRCPerserver
   end
 
   # find the remaining Swift objects that don't have corresponding items in CWRC
-  # p "Remaining Swift objects; objects not found in CWRC (likely deleted by CWRC)"
   swift_objs&.each do |key, swift_obj|
     # CSV content
     puts ",,#{key},#{swift_obj[:last_modified]},#{swift_obj[:bytes]},d"

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -41,12 +41,11 @@ require 'swift_ingest'
 require_relative 'cwrc_common'
 
 module CWRCPerserver
-
   # status IDs
-  STATUS_OK = ''
-  STATUS_E_SIZE = 's' # error: size zero or too small
-  STATUS_I_FLAG = 'x' # flagged for preservation
-  STATUS_I_DEL = 'd' # missing from the CWRC side while Swift contains a copy
+  STATUS_OK = ''.freeze
+  STATUS_E_SIZE = 's'.freeze # error: size zero or too small
+  STATUS_I_FLAG = 'x'.freeze # flagged for preservation
+  STATUS_I_DEL = 'd'.freeze # missing from the CWRC side while Swift contains a copy
 
   opt_summary_output = false
   ARGV.options do |opts|
@@ -92,19 +91,17 @@ module CWRCPerserver
   # https://github.com/ruby-openstack/ruby-openstack/issues/37
   # https://github.com/ruby-openstack/ruby-openstack/blob/master/lib/openstack/swift/container.rb#L100
 
-  swift_objs = swift_container.objects_detail()
-  while swift_objs.count < swift_container.container_metadata[:count].to_i 
-    swift_objs = swift_objs.merge(
-                   swift_container.objects_detail(marker: swift_objs.keys.last)
-                   )
+  swift_objs = swift_container.objects_detail
+  while swift_objs.count < swift_container.container_metadata[:count].to_i
+    swift_objs = swift_objs.merge(swift_container.objects_detail(marker: swift_objs.keys.last))
   end
 
   # TODO: use CSV gem
   # CSV header
   puts "cwrc_pid (#{cwrc_objs.count}),"\
-    "cwrc_mtime (#{DateTime.now}),"\
+    "cwrc_mtime (#{Time.now}),"\
     "swift_id (#{swift_container.container_metadata[:count]}),"\
-    "swift_timestamp,swift_bytes,status"
+    'swift_timestamp,swift_bytes,status'
 
   # TODO: find a better way to merge CWRC and Swift hashes into an output format
   # for each cwrc object
@@ -142,7 +139,6 @@ module CWRCPerserver
     if !opt_summary_output || (opt_summary_output && status != STATUS_OK)
       puts "#{cwrc_pid},#{cwrc_mtime},#{swift_id},#{swift_timestamp},#{swift_bytes},#{status}"
     end
-
   end
 
   # find the remaining Swift objects that don't have corresponding items in CWRC
@@ -151,5 +147,4 @@ module CWRCPerserver
     # CSV content
     puts ",,#{key},#{swift_obj[:last_modified]},#{swift_obj[:bytes]},d"
   end
-
 end

--- a/cwrc_common.rb
+++ b/cwrc_common.rb
@@ -83,7 +83,7 @@ module CWRCPerserver
       http_read_timeout += 30
       retry
     end
-    open(cwrc_file, 'wb') do |file|
+    File.open(cwrc_file, 'wb') do |file|
       file.write(obj_response.body)
     end
   end


### PR DESCRIPTION
Provides a new Ruby script that builds a CSV formatted audit report comparing the contents of the CWRC repository to content with the UAL OpenStack Swift preservation environment.

The report pulls input from two disparate sources: CWRC repository and UAL OpenStack Swift preservation service. The report links the content based on object id and outputs the linked information in csv rows that included the fields: the CWRC object PIDs and modification date/times, UAL Swift ID, modification time, and size along with a column indicating the preservation status (i.e., indicating if modification time comparison between Swift and CWRC indicates a need for preservation, or if the size of the Swift object is zero, etc)