### PR TITLE
Use Swift metadata 'last-mod-timestamp' instead of 'timestamp'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 cache: bundler
 
 before_install:
-  - gem install bundler -v "~>1.0"
+  - gem install bundler
   - gem update bundler
 
 rvm:
   - 2.3.3
+  - 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: bundler
 
 before_install:
-  - gem install bundler
+  - gem install bundler -v "~>1.0"
   - gem update bundler
 
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bundler', '~> 1.14'
+gem 'bundler', '~> 2.0'
 gem 'http-cookie'
 gem 'json'
 gem 'logger'

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -93,9 +93,9 @@ module CWRCPerserver
 
   # Iterate via markers
   # https://github.com/ruby-openstack/ruby-openstack/blob/d9c8aa19488062e483771a9168d24f2626fe688b/lib/openstack/swift/container.rb#L100
-  swift_objs = swift_container.objects_detail
+  swift_objs = swift_container.objects
   while swift_objs.count < swift_container.container_metadata[:count].to_i
-    swift_objs = swift_objs.merge(swift_container.objects_detail(marker: swift_objs.keys.last))
+    swift_objs = swift_objs.merge(swift_container.objects(marker: swift_objs.keys.last))
   end
 
   # TODO: use CSV gem
@@ -114,8 +114,9 @@ module CWRCPerserver
     swift_id = cwrc_pid.sub ':', '_'
 
     if swift_objs.key?(swift_id)
-      swift_timestamp = swift_objs[swift_id][:last_modified]
-      swift_bytes = swift_objs[swift_id][:bytes]
+      swift_obj = swift_container.objects(swift_id)
+      swift_timestamp = swift_obj.metadata['last-mod-timestamp']
+      swift_bytes = swift_obj.bytes
       # note: CWRC uses zulu while Swift is local timezone (assumption)
       # If timestamps don't match then report Swift object older than CWRC
       status = if Time.parse(cwrc_mtime) > Time.parse(swift_timestamp)

--- a/cwrc_common.rb
+++ b/cwrc_common.rb
@@ -85,7 +85,7 @@ module CWRCPerserver
           # to detect transport corruption
           raise CWRCArchivingError unless response['CWRC-CHECKSUM'].tr('"', '') == Digest::MD5.file(cwrc_file).to_s
         elsif response.is_a? Net::HTTPServerError
-          raise Net::HTTPServerError.new("Failed request #{obj_path} with http status #{response.code}", response.code)
+          raise Net::HTTPError.new("Failed request #{obj_path} with http status #{response.code}", response.code)
         else
           raise Net::HTTPError.new("Failed request #{obj_path} with http status #{response.code}", response.code)
         end

--- a/cwrc_common.rb
+++ b/cwrc_common.rb
@@ -90,7 +90,8 @@ module CWRCPerserver
           raise Net::HTTPError.new("Failed request #{obj_path} with http status #{response.code}", response.code)
         end
       end
-    rescue Net::ReadTimeout,
+    rescue CWRCArchivingError,
+           Net::ReadTimeout,
            Net::HTTPBadResponse,
            Net::HTTPHeaderSyntaxError,
            Net::HTTPServerError,

--- a/cwrc_preserver.rb
+++ b/cwrc_preserver.rb
@@ -108,6 +108,7 @@ module CWRCPerserver
     force_deposit = false || !reprocess.empty?
     begin
       swift_file = swift_depositer.get_file_from_swit(cwrc_file, ENV['CWRC_SWIFT_CONTAINER']) unless force_deposit
+      log.debug("SWIFT LOOKUP: #{swift_file.nil? ? 'not found' : swift_file.metadata['last-mod-timestamp']}")
     rescue StandardError => e
       force_deposit = true
       log.debug("Force deposit in swift: #{cwrc_obj['pid']} #{e.message}")
@@ -117,8 +118,8 @@ module CWRCPerserver
     next unless force_deposit ||
                 swift_file.nil? ||
                 swift_file.bytes.to_f.zero? ||
-                swift_file.metadata['timestamp'].nil? ||
-                cwrc_obj['timestamp'].to_time > swift_file.metadata['timestamp'].to_time
+                swift_file.metadata['last-mod-timestamp'].nil? ||
+                cwrc_obj['timestamp'].to_time > swift_file.metadata['last-mod-timestamp'].to_time
 
     # download object from cwrc
     start_time = Time.now

--- a/cwrc_preserver.rb
+++ b/cwrc_preserver.rb
@@ -126,7 +126,8 @@ module CWRCPerserver
     log.debug("DOWNLOADING from CWRC: #{cwrc_obj['pid']}")
     begin
       download_cwrc_obj(cookie, cwrc_obj, cwrc_file_tmp_path)
-    rescue Net::ReadTimeout,
+    rescue CWRCArchivingError,
+           Net::ReadTimeout,
            Net::HTTPBadResponse,
            Net::HTTPHeaderSyntaxError,
            Net::HTTPServerError,
@@ -136,6 +137,7 @@ module CWRCPerserver
            Errno::EINVAL,
            EOFError => e
       log.error("ERROR DOWNLOADING: #{cwrc_obj['pid']} - #{e.class} #{e.message} #{e.backtrace}")
+      File.open(except_file, 'a') { |err_file| err_file.write("#{cwrc_obj['pid']}\n") }
       next
     end
 

--- a/cwrc_reconcile.rb
+++ b/cwrc_reconcile.rb
@@ -40,7 +40,7 @@ module CWRCPerserver
       print "OBJECT MISSING FROM SWIFT: #{cwrc_file_str}\n"
       File.open('swift_missing_objs.txt', 'a') { |miss_file| miss_file.write("#{cwrc_file_str}\n") }
     else
-      mod_dt = swift_file.metadata['timestamp'].to_s
+      mod_dt = swift_file.metadata['last-mod-timestamp'].to_s
       File.open('swift_objs.txt', 'a') { |ok_file| ok_file.write("#{cwrc_file_str} #{mod_dt}\n") }
     end
   end


### PR DESCRIPTION
Fixes #14

- Fixes test to determine if the OpenStack Swift object is outdated with respect to the CWRC repository objects (use 'last-mod-timestamp' metadata key). 
- updates bundler version
- adds Ruby 2.4 to the Travis tests

A request for the metadata from the OpenStack Swift instance returns a key `last-mod-timestamp`
```
irb(main):056:0> p swift_file.metadata
{"project-id"=>"tpatt_f39b0d8f-ffb4-4e31-86d5-f8fbb90ac38c", "last-mod-timestamp"=>"2019-01-15T04:56:33.772Z", "aip-version"=>"1.0", "project"=>"CWRC", "promise"=>"bronze"}
=> {"project-id"=>"tpatt_f39b0d8f-ffb4-4e31-86d5-f8fbb90ac38c", "last-mod-timestamp"=>"2019-01-15T04:56:33.772Z", "aip-version"=>"1.0", "project"=>"CWRC", "promise"=>"bronze"}
```
