### PR TITLE
fixes #11: spelling of 'preserver'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bundler', '~> 1.14'
+gem 'bundler', '~> 2.0'
 gem 'http-cookie'
 gem 'json'
 gem 'logger'

--- a/cwrc_audit_report.rb
+++ b/cwrc_audit_report.rb
@@ -42,7 +42,7 @@ require 'swift_ingest'
 
 require_relative 'cwrc_common'
 
-module CWRCPerserver
+module CWRCPreserver
   # status IDs
   STATUS_OK = ''.freeze
   STATUS_E_SIZE = 's'.freeze # error: size zero or too small

--- a/cwrc_common.rb
+++ b/cwrc_common.rb
@@ -4,7 +4,7 @@ require 'net/http'
 require 'json'
 require 'http-cookie'
 
-module CWRCPerserver
+module CWRCPreserver
   class CWRCArchivingError < StandardError; end
 
   def self.retrieve_cookie

--- a/cwrc_preserver.rb
+++ b/cwrc_preserver.rb
@@ -16,7 +16,7 @@ require 'logger'
 require 'time'
 require_relative 'cwrc_common'
 
-module CWRCPerserver
+module CWRCPreserver
   # process command line arguments
   debug_level = false
   start_dt = ''

--- a/cwrc_preserver_test.rb
+++ b/cwrc_preserver_test.rb
@@ -15,7 +15,7 @@ class VCRTest < Test::Unit::TestCase
 
   def test_init_environment
     assert_nothing_raised do
-      CWRCPerserver.init_env(TEST_CONFIG)
+      CWRCPreserver.init_env(TEST_CONFIG)
     end
     refute_empty ENV['SWIFT_USERNAME']
     refute_empty ENV['SWIFT_PASSWORD']
@@ -33,8 +33,8 @@ class VCRTest < Test::Unit::TestCase
   def test_get_cookie
     VCR.use_cassette('cookie') do
       assert_nothing_raised do
-        CWRCPerserver.init_env(TEST_CONFIG)
-        refute_empty CWRCPerserver.retrieve_cookie
+        CWRCPreserver.init_env(TEST_CONFIG)
+        refute_empty CWRCPreserver.retrieve_cookie
       end
     end
   end
@@ -43,9 +43,9 @@ class VCRTest < Test::Unit::TestCase
     VCR.use_cassette('cookie') do
       VCR.use_cassette('all_objects') do
         assert_nothing_raised do
-          CWRCPerserver.init_env(TEST_CONFIG)
-          cookie = CWRCPerserver.retrieve_cookie
-          cwrc_objs = CWRCPerserver.get_cwrc_objs(cookie, '')
+          CWRCPreserver.init_env(TEST_CONFIG)
+          cookie = CWRCPreserver.retrieve_cookie
+          cwrc_objs = CWRCPreserver.get_cwrc_objs(cookie, '')
           refute_empty cwrc_objs
           assert cwrc_objs.count == 99_396
         end
@@ -57,9 +57,9 @@ class VCRTest < Test::Unit::TestCase
     VCR.use_cassette('cookie') do
       VCR.use_cassette('updated_objects') do
         assert_nothing_raised do
-          CWRCPerserver.init_env(TEST_CONFIG)
-          cookie = CWRCPerserver.retrieve_cookie
-          cwrc_objs = CWRCPerserver.get_cwrc_objs(cookie, '2017-01-01T15:29:21.374Z')
+          CWRCPreserver.init_env(TEST_CONFIG)
+          cookie = CWRCPreserver.retrieve_cookie
+          cwrc_objs = CWRCPreserver.get_cwrc_objs(cookie, '2017-01-01T15:29:21.374Z')
           refute_empty cwrc_objs
           assert cwrc_objs.count == 50
         end
@@ -73,9 +73,9 @@ class VCRTest < Test::Unit::TestCase
         cwrc_obj = { 'pid' => 'islandora:eb608bc8-059b-4cfc-bc13-358823009373' }
         cwrc_file = "#{cwrc_obj['pid'].tr(':', '_')}.zip"
         assert_nothing_raised do
-          CWRCPerserver.init_env(TEST_CONFIG)
-          cookie = CWRCPerserver.retrieve_cookie
-          CWRCPerserver.download_cwrc_obj(cookie, cwrc_obj, cwrc_file)
+          CWRCPreserver.init_env(TEST_CONFIG)
+          cookie = CWRCPreserver.retrieve_cookie
+          CWRCPreserver.download_cwrc_obj(cookie, cwrc_obj, cwrc_file)
         end
         assert !cwrc_obj['timestamp'].nil?
         assert cwrc_obj['timestamp'] = '2015-02-13T18:24.492Z'
@@ -91,9 +91,9 @@ class VCRTest < Test::Unit::TestCase
         cwrc_obj = { 'pid' => 'islandora:eb608bc8-059b-4cfc-bc13-358823009373' }
         cwrc_file = "#{cwrc_obj['pid'].tr(':', '_')}.zip"
         assert_raise do
-          CWRCPerserver.init_env(TEST_CONFIG)
-          cookie = CWRCPerserver.retrieve_cookie
-          CWRCPerserver.download_cwrc_obj(cookie, cwrc_obj, cwrc_file)
+          CWRCPreserver.init_env(TEST_CONFIG)
+          cookie = CWRCPreserver.retrieve_cookie
+          CWRCPreserver.download_cwrc_obj(cookie, cwrc_obj, cwrc_file)
         end
         assert !File.exist?(cwrc_file)
         FileUtils.rm_rf(cwrc_file) if File.exist?(cwrc_file)

--- a/cwrc_reconcile.rb
+++ b/cwrc_reconcile.rb
@@ -6,7 +6,7 @@ require 'swift_ingest'
 require 'optparse'
 require_relative 'cwrc_common'
 
-module CWRCPerserver
+module CWRCPreserver
   # process command line arguments -h or --help
   file = __FILE__
   ARGV.options do |opts|


### PR DESCRIPTION
fixes #11 

Fixes the misspelling of 'preserver'