### PR TITLE
Create Gemfile.lock; downgrade bundler to v1 from v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - gem update bundler
 
 rvm:
-  - 2.3.3
-  - 2.4.0
+  - 2.4.5
   - 2.5.3
   - 2.6.1

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :development, :test do
   gem 'rubocop', '~> 0.51'
   gem 'rubocop-rspec', '~> 1.15.1'
   gem 'test-unit'
-  gem 'webmock'
   gem 'vcr', '~> 3.0'
+  gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,12 @@ gem 'http-cookie'
 gem 'json'
 gem 'logger'
 gem 'rake'
-gem 'rubocop', '~> 0.51'
-gem 'rubocop-rspec', '~> 1.15.1'
 gem 'swift_ingest', '~> 0.4.0'
-gem 'test-unit'
-gem 'vcr', '~> 3.0'
-gem 'webmock'
+
+group :development, :test do
+  gem 'rubocop', '~> 0.51'
+  gem 'rubocop-rspec', '~> 1.15.1'
+  gem 'test-unit'
+  gem 'webmock'
+  gem 'vcr', '~> 3.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bundler', '~> 2.0'
+gem 'bundler', '~> 1.17'
 gem 'http-cookie'
 gem 'json'
 gem 'logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,85 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    concurrent-ruby (1.1.4)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    hashdiff (0.3.8)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (1.5.2)
+      concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.2)
+    json (2.1.0)
+    logger (1.3.0)
+    minitest (5.11.3)
+    mysql2 (0.4.10)
+    openstack (3.3.20)
+      json
+    parallel (1.13.0)
+    parser (2.6.0.0)
+      ast (~> 2.4.0)
+    power_assert (1.1.3)
+    powerpack (0.1.2)
+    public_suffix (3.0.3)
+    rainbow (3.0.0)
+    rake (12.3.2)
+    rubocop (0.63.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.15.1)
+      rubocop (>= 0.42.0)
+    ruby-progressbar (1.10.0)
+    safe_yaml (1.0.4)
+    swift_ingest (0.4.1)
+      activesupport (~> 5.0)
+      mysql2 (~> 0.4.6)
+      openstack (~> 3.3, >= 3.3.10)
+    test-unit (3.2.9)
+      power_assert
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
+    unicode-display_width (1.4.1)
+    vcr (3.0.3)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.0)
+  http-cookie
+  json
+  logger
+  rake
+  rubocop (~> 0.51)
+  rubocop-rspec (~> 1.15.1)
+  swift_ingest (~> 0.4.0)
+  test-unit
+  vcr (~> 3.0)
+  webmock
+
+BUNDLED WITH
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     domain_name (0.5.20180417)
@@ -17,40 +17,40 @@ GEM
     hashdiff (0.3.8)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.5.2)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
-    json (2.1.0)
+    json (2.2.0)
     logger (1.3.0)
     minitest (5.11.3)
     mysql2 (0.4.10)
     openstack (3.3.20)
       json
-    parallel (1.13.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
-    power_assert (1.1.3)
-    powerpack (0.1.2)
+    power_assert (1.1.4)
+    psych (3.1.0)
     public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.63.0)
+    rubocop (0.67.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
+      unicode-display_width (>= 1.4.0, < 1.6)
     rubocop-rspec (1.15.1)
       rubocop (>= 0.42.0)
     ruby-progressbar (1.10.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     swift_ingest (0.4.1)
       activesupport (~> 5.0)
       mysql2 (~> 0.4.6)
       openstack (~> 3.3, >= 3.3.10)
-    test-unit (3.2.9)
+    test-unit (3.3.1)
       power_assert
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -58,7 +58,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.5.0)
     vcr (3.0.3)
     webmock (3.5.1)
       addressable (>= 2.3.6)
@@ -69,7 +69,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler (~> 1.17)
   http-cookie
   json
   logger
@@ -82,4 +82,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
ref #4 
- Gemfile: pin bundler to v1 as v2 is incompatible with the current rpm build environment
- Gemfile: add development/test group to remove dev tools from production
- Add Gemfile.lock for ITS rpm build script to run.
- update Travis Ruby versions.